### PR TITLE
Add RequestPublisher

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.3
 
 import PackageDescription
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# combine-requests
+# Combine Requests
+
 Helpers for working with requests in Combine.
+
+## Example
+
+```swift
+URLSession.shared
+    .dataTaskPublisher(for: URL(string: "https://jsonplaceholder.typicode.com/users")!)
+    .request()
+    .assign(outputTo: \.output, on: self)
+```

--- a/Sources/CombineRequests/RequestPublisher.swift
+++ b/Sources/CombineRequests/RequestPublisher.swift
@@ -1,0 +1,38 @@
+//
+//  RequestPublisher.swift
+//  CombineRequests
+//
+//  Created by Thomas Leese on 18/10/2020.
+//
+
+import Combine
+
+/// Publishes the state of a request from any other publisher.
+public class RequestPublisher<StateSuccess, StateFailure>: Publisher where StateFailure: Error {
+    public typealias Output = RequestState<StateSuccess, StateFailure>
+    public typealias Failure = Never
+
+    let subject = CurrentValueSubject<Output, Failure>(.loading)
+    var cancellable: AnyCancellable?
+
+    public init<P>(_ publisher: P) where P: Publisher, P.Output == StateSuccess, P.Failure == StateFailure {
+        cancellable = publisher
+            .sink { completion in
+                if case .failure(let error) = completion {
+                    self.subject.send(.failure(error))
+                }
+            } receiveValue: { data in
+                self.subject.send(.success(data))
+            }
+    }
+
+    public func receive<S>(subscriber: S) where S: Subscriber, S.Input == Output, S.Failure == Failure {
+        subject.receive(subscriber: subscriber)
+    }
+}
+
+extension Publisher {
+    public func request() -> RequestPublisher<Self.Output, Self.Failure> {
+        RequestPublisher(self)
+    }
+}

--- a/Sources/CombineRequests/RequestState.swift
+++ b/Sources/CombineRequests/RequestState.swift
@@ -28,9 +28,9 @@ import Foundation
     }
 
     /// The data if the request was successful.
-    var data: Success? {
-        if case .success(let data) = self {
-            return data
+    var output: Success? {
+        if case .success(let output) = self {
+            return output
         } else {
             return nil
         }

--- a/Tests/CombineRequestsTests/RequestPublisherTests.swift
+++ b/Tests/CombineRequestsTests/RequestPublisherTests.swift
@@ -1,0 +1,41 @@
+//
+//  RequestPublisherTests.swift
+//  CombineRequests
+//
+//  Created by Thomas Leese on 18/10/2020.
+//
+
+import Combine
+import XCTest
+
+@testable import CombineRequests
+
+final class RequestPublisherTests: XCTestCase {
+
+    struct ExampleError: Error, Equatable { }
+
+    func testPublisherIsLoading() {
+        var isLoading: Bool?
+        _ = PassthroughSubject<String, ExampleError>().request().sink { state in
+            isLoading = state.isLoading
+        }
+        XCTAssertTrue(isLoading ?? false)
+    }
+
+    func testPublisherOutput() {
+        var output: String?
+        _ = Just("output").request().sink { state in
+            output = state.output
+        }
+        XCTAssertEqual(output, "output")
+    }
+
+    func testPublisherError() {
+        var error: ExampleError?
+        _ = Result<String, ExampleError>.failure(.init()).publisher.request().sink { state in
+            error = state.error
+        }
+        XCTAssertEqual(error, ExampleError())
+    }
+
+}

--- a/Tests/CombineRequestsTests/RequestStateTests.swift
+++ b/Tests/CombineRequestsTests/RequestStateTests.swift
@@ -23,21 +23,21 @@ final class RequestStateTests: XCTestCase {
         state = .success("output")
         XCTAssertFalse(state.isLoading)
 
-        state = .failure(NSError())
+        state = .failure(ExampleError())
         XCTAssertFalse(state.isLoading)
     }
 
-    func testData() {
+    func testOutput() {
         var state: RequestState<String, Error>
 
         state = .loading
-        XCTAssertNil(state.data)
+        XCTAssertNil(state.output)
 
         state = .success("output")
-        XCTAssertEqual(state.data, "output")
+        XCTAssertEqual(state.output, "output")
 
         state = .failure(ExampleError())
-        XCTAssertNil(state.data)
+        XCTAssertNil(state.output)
     }
 
     func testError() {


### PR DESCRIPTION
This takes another publisher and converts it into a publisher which outputs a `RequestState`.